### PR TITLE
feat: add admin-friendly configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# Local secrets
+appsettings.Local.json
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ sequenceDiagram
 
 For a more detailed setup guide, see [docs/installation.md](docs/installation.md).
 
+Administrators should review the configuration guide at [docs/Admin-Config-Guide.md](docs/Admin-Config-Guide.md).
+Key files under `src/AstraID.Api`:
+- `appsettings.json` – defaults without secrets
+- `appsettings.Production.json` – production defaults
+- `appsettings.Local.json` – local overrides and secrets (not committed)
+
 1. Clone the repository
 2. Configure environment variables:
    ```bash

--- a/docs/Admin-Config-Guide.md
+++ b/docs/Admin-Config-Guide.md
@@ -1,0 +1,49 @@
+# AstraID Admin Configuration Guide
+
+This guide walks administrators through configuring AstraID using JSON files or environment variables.
+
+## Quick Start
+1. Copy the local template:
+   - **Linux/macOS:** `cp src/AstraID.Api/appsettings.Local.json.example src/AstraID.Api/appsettings.Local.json`
+   - **Windows:** `copy src\AstraID.Api\appsettings.Local.json.example src\AstraID.Api\appsettings.Local.json`
+2. Edit `appsettings.Local.json` with your connection string and OAuth introspection credentials.
+3. Run the API and verify configuration with `curl http://localhost:5000/_diag/config/validate` (development only).
+
+## Configuration Files
+- `appsettings.json` – default values.
+- `appsettings.Production.json` – overrides for production deployments.
+- `appsettings.Local.json` – local secrets and overrides. This file is **gitignored**.
+
+## Key Settings
+| Key | Description | Example |
+|-----|-------------|---------|
+| `ConnectionStrings:Default` | Database connection string | `Server=localhost;Database=AstraId;User Id=sa;Password=StrongPass;TrustServerCertificate=True` |
+| `AstraId:Issuer` | Public base URL of the identity server | `https://id.example.com` |
+| `AstraId:AllowedCors` | Array of allowed HTTPS origins for CORS | `["https://app.example.com"]` |
+| `Auth:Introspection:ClientId` | Client id used for token introspection | `astra-admin` |
+| `Auth:Introspection:ClientSecret` | Secret for introspection client | `p@ssw0rd` |
+
+## Environment Variable Overrides
+Any setting can be overridden with environment variables using `__` as the separator.
+
+### Linux/macOS
+```bash
+export ConnectionStrings__Default="Server=..."
+export AstraId__Issuer="https://id.example.com"
+```
+
+### Windows PowerShell
+```powershell
+$env:ConnectionStrings__Default = "Server=..."
+$env:AstraId__Issuer = "https://id.example.com"
+```
+
+## Troubleshooting
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Configuration error in 'AstraIdOptions': The Issuer field is required.` | Missing `AstraId:Issuer` | Set the value in `appsettings.Local.json` or environment variable `AstraId__Issuer` |
+| `/ _diag/config` shows `***` for a value | Secret value is masked | Check your local file or environment variable |
+| Validation endpoint returns `ERROR` | One or more settings failed validation | Review the `Message` and update the relevant key |
+
+## More Information
+See the Swagger UI "Admin Setup" section when running in development for required keys and links to this guide.

--- a/scripts/config-set.ps1
+++ b/scripts/config-set.ps1
@@ -1,0 +1,17 @@
+param(
+    [string]$Command = "help"
+)
+
+switch ($Command) {
+    "copy" {
+        Copy-Item -Path "src/AstraID.Api/appsettings.Local.json.example" -Destination "src/AstraID.Api/appsettings.Local.json" -ErrorAction SilentlyContinue
+        Write-Host "Local config created at src/AstraID.Api/appsettings.Local.json"
+    }
+    "validate" {
+        Invoke-RestMethod -Uri "http://localhost:5000/_diag/config/validate" -UseBasicParsing
+    }
+    default {
+        Write-Host "Usage: ./config-set.ps1 -Command <copy|validate>"
+        Write-Host "Example:`n$env:AstraId__Issuer='https://id.example.com'"
+    }
+}

--- a/scripts/config-set.sh
+++ b/scripts/config-set.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Examples:
+#   export AstraId__Issuer=https://id.example.com
+#   export ConnectionStrings__Default="Server=..."
+#   ./scripts/config-set.sh copy
+#   ./scripts/config-set.sh validate
+
+set -e
+cmd=$1
+case "$cmd" in
+  copy)
+    cp -n src/AstraID.Api/appsettings.Local.json.example src/AstraID.Api/appsettings.Local.json
+    echo "Local config created at src/AstraID.Api/appsettings.Local.json"
+    ;;
+  validate)
+    curl -s http://localhost:5000/_diag/config/validate
+    ;;
+  *)
+    echo "Usage: config-set.sh {copy|validate}"
+    ;;
+ esac

--- a/src/AstraID.Api/Options/AstraIdOptions.cs
+++ b/src/AstraID.Api/Options/AstraIdOptions.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AstraID.Api.Options;
+
+public class AstraIdOptions
+{
+    [Required]
+    [Url]
+    public string Issuer { get; set; } = string.Empty;
+
+    [Required]
+    public string[] AllowedCors { get; set; } = Array.Empty<string>();
+
+    public RateLimitOptions RateLimit { get; set; } = new();
+
+    public bool AutoMigrate { get; set; }
+    public bool RunSeed { get; set; }
+}
+
+public class RateLimitOptions
+{
+    [Range(1, 1000)]
+    public int Rps { get; set; }
+
+    [Range(1, 1000)]
+    public int Burst { get; set; }
+}

--- a/src/AstraID.Api/Options/AuthOptions.cs
+++ b/src/AstraID.Api/Options/AuthOptions.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AstraID.Api.Options;
+
+public class AuthOptions
+{
+    public TokenLifetimeOptions TokenLifetimes { get; set; } = new();
+
+    public CertificateOptions Certificates { get; set; } = new();
+
+    public IntrospectionOptions Introspection { get; set; } = new();
+}
+
+public class TokenLifetimeOptions
+{
+    [Range(1, int.MaxValue)]
+    public int AccessMinutes { get; set; } = 60;
+
+    [Range(1, int.MaxValue)]
+    public int IdentityMinutes { get; set; } = 15;
+
+    [Range(1, int.MaxValue)]
+    public int RefreshDays { get; set; } = 14;
+}
+
+public class CertificateOptions
+{
+    public string[] Signing { get; set; } = Array.Empty<string>();
+    public string[] Encryption { get; set; } = Array.Empty<string>();
+}
+
+public class IntrospectionOptions
+{
+    [Required]
+    public string ClientId { get; set; } = string.Empty;
+
+    [Required]
+    public string ClientSecret { get; set; } = string.Empty;
+}

--- a/src/AstraID.Api/Program.cs
+++ b/src/AstraID.Api/Program.cs
@@ -10,14 +10,39 @@ using Serilog;
 using Hellang.Middleware.ProblemDetails;
 using AstraID.Api.Infrastructure.Audit;
 using Microsoft.AspNetCore.HttpOverrides;
+using AstraID.Api.Options;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.Sources.Clear();
+builder.Configuration
+    .SetBasePath(builder.Environment.ContentRootPath)
+    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+    .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true)
+    .AddEnvironmentVariables();
+
+var config = builder.Configuration;
 
 #if DEBUG
 builder.Configuration.AddUserSecrets<Program>(optional: true);
 #endif
 
 builder.Host.UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration));
+
+builder.Services.AddOptions<AstraIdOptions>()
+    .Bind(config.GetSection("AstraId"))
+    .ValidateDataAnnotations()
+    .Validate(options => options.AllowedCors.All(origin => Uri.TryCreate(origin, UriKind.Absolute, out var uri) && uri.Scheme == Uri.UriSchemeHttps),
+        "CORS origins must be absolute HTTPS URLs")
+    .Validate(options => Uri.IsWellFormedUriString(options.Issuer, UriKind.Absolute), "Invalid Issuer URL")
+    .ValidateOnStart();
+
+builder.Services.AddOptions<AuthOptions>()
+    .Bind(config.GetSection("Auth"))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 
 builder.Services
     .AddAstraIdApplication()
@@ -38,7 +63,19 @@ if (builder.Environment.IsDevelopment())
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {
-        c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo { Title = "AstraID API", Version = "v1" });
+        c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+        {
+            Title = "AstraID API",
+            Version = "v1",
+            Description = @"## Admin Setup
+See docs/Admin-Config-Guide.md for configuration instructions.
+
+Required keys:
+- `ConnectionStrings:Default`
+- `AstraId:Issuer`
+- `Auth:Introspection:ClientId`
+- `Auth:Introspection:ClientSecret`"
+        });
         var scheme = new Microsoft.OpenApi.Models.OpenApiSecurityScheme
         {
             Name = "Authorization",
@@ -60,7 +97,24 @@ if (builder.Environment.IsDevelopment())
     });
 }
 
-var app = builder.Build();
+WebApplication app;
+try
+{
+    app = builder.Build();
+}
+catch (OptionsValidationException ex)
+{
+    foreach (var failure in ex.Failures)
+    {
+        Console.Error.WriteLine($"Configuration error in '{ex.OptionsName}': {failure}");
+    }
+    if (builder.Environment.IsProduction())
+    {
+        Environment.ExitCode = 1;
+        return;
+    }
+    throw;
+}
 
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
@@ -79,6 +133,44 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+
+    app.MapGet("/_diag/config", (IConfiguration configuration) =>
+    {
+        var root = (IConfigurationRoot)configuration;
+        var masked = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ConnectionStrings:Default",
+            "Auth:Introspection:ClientSecret"
+        };
+        var snapshot = new Dictionary<string, object?>();
+        foreach (var kvp in configuration.AsEnumerable())
+        {
+            if (string.IsNullOrEmpty(kvp.Value)) continue;
+            var provider = root.Providers.First(p => p.TryGet(kvp.Key, out _));
+            var value = masked.Contains(kvp.Key) ? "***" : kvp.Value;
+            snapshot[kvp.Key] = new { value, source = provider.ToString() };
+        }
+        return Results.Json(snapshot);
+    });
+
+    app.MapGet("/_diag/config/validate", (IServiceProvider sp) =>
+    {
+        var issues = new List<object>();
+        try { _ = sp.GetRequiredService<IOptions<AstraIdOptions>>().Value; }
+        catch (OptionsValidationException ex)
+        {
+            foreach (var f in ex.Failures)
+                issues.Add(new { Key = ex.OptionsName, Message = f, HowToFix = string.Empty });
+        }
+        try { _ = sp.GetRequiredService<IOptions<AuthOptions>>().Value; }
+        catch (OptionsValidationException ex)
+        {
+            foreach (var f in ex.Failures)
+                issues.Add(new { Key = ex.OptionsName, Message = f, HowToFix = string.Empty });
+        }
+        var status = issues.Count == 0 ? "OK" : "ERROR";
+        return Results.Json(new { status, issues });
+    });
 }
 
 app.MapControllers();

--- a/src/AstraID.Api/appsettings.Local.json.example
+++ b/src/AstraID.Api/appsettings.Local.json.example
@@ -1,0 +1,11 @@
+{
+  "ConnectionStrings": {
+    "Default": "Server=localhost;Database=AstraId;User Id=sa;Password=<YourStrong!Passw0rd>;TrustServerCertificate=True"
+  },
+  "Auth": {
+    "Introspection": {
+      "ClientId": "<client-id>",
+      "ClientSecret": "<client-secret>"
+    }
+  }
+}

--- a/src/AstraID.Api/appsettings.Production.json
+++ b/src/AstraID.Api/appsettings.Production.json
@@ -12,5 +12,5 @@
     "Certificates": { "Signing": [], "Encryption": [] },
     "Introspection": { "ClientId": "", "ClientSecret": "" }
   },
-  "Serilog": { "MinimumLevel": "Information", "WriteTo": [ { "Name": "Console" } ] }
+  "Serilog": { "MinimumLevel": "Warning", "WriteTo": [ { "Name": "Console" } ] }
 }


### PR DESCRIPTION
## Summary
- overhaul appsettings with production and local templates
- add strongly typed AstraId and Auth options with validation
- expose dev-only config diagnostics endpoints and scripts/docs for admins

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d00bebc832693c2bec6e693c351