### PR TITLE
Add configuration validation and JSONC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,5 @@ MigrationBackup/
 FodyWeavers.xsd
 # Local secrets
 appsettings.Local.json
+appsettings.Local.jsonc
 

--- a/docs/Admin-Config-Guide.md
+++ b/docs/Admin-Config-Guide.md
@@ -4,9 +4,9 @@ This guide walks administrators through configuring AstraID using JSON files or 
 
 ## Quick Start
 1. Copy the local template:
-   - **Linux/macOS:** `cp src/AstraID.Api/appsettings.Local.json.example src/AstraID.Api/appsettings.Local.json`
-   - **Windows:** `copy src\AstraID.Api\appsettings.Local.json.example src\AstraID.Api\appsettings.Local.json`
-2. Edit `appsettings.Local.json` with your connection string and OAuth introspection credentials.
+   - **Linux/macOS:** `./scripts/config-new-local.sh`
+   - **Windows:** `powershell .\scripts\config-new-local.ps1`
+2. Edit `appsettings.Local.json` and replace all `CHANGE_ME` placeholders.
 3. Run the API and verify configuration with `curl http://localhost:5000/_diag/config/validate` (development only).
 
 ## Configuration Files
@@ -17,11 +17,12 @@ This guide walks administrators through configuring AstraID using JSON files or 
 ## Key Settings
 | Key | Description | Example |
 |-----|-------------|---------|
-| `ConnectionStrings:Default` | Database connection string | `Server=localhost;Database=AstraId;User Id=sa;Password=StrongPass;TrustServerCertificate=True` |
-| `AstraId:Issuer` | Public base URL of the identity server | `https://id.example.com` |
-| `AstraId:AllowedCors` | Array of allowed HTTPS origins for CORS | `["https://app.example.com"]` |
-| `Auth:Introspection:ClientId` | Client id used for token introspection | `astra-admin` |
-| `Auth:Introspection:ClientSecret` | Secret for introspection client | `p@ssw0rd` |
+| `ConnectionStrings:Default` | Database connection string | `Server=YOUR_HOST\SQLEXPRESS;Database=AstraID;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;` |
+| `AstraId:Issuer` | Public base URL of the identity server (HTTPS) | `https://id.example.com` |
+| `AstraId:AllowedCors` | Array of allowed browser origins | `["https://app.example.com"]` |
+| `Auth:Certificates:Signing[n].Path` | Path to a PFX signing cert | `C:\\certs\\astraid-signing.pfx` |
+| `Auth:Introspection:ClientId` | (When ValidationMode = Introspection) client id for introspection | `admin-cli` |
+| `Auth:Introspection:ClientSecret` | (When ValidationMode = Introspection) client secret | `p@ssw0rd` |
 
 ## Environment Variable Overrides
 Any setting can be overridden with environment variables using `__` as the separator.
@@ -30,12 +31,18 @@ Any setting can be overridden with environment variables using `__` as the separ
 ```bash
 export ConnectionStrings__Default="Server=..."
 export AstraId__Issuer="https://id.example.com"
+export AstraId__AllowedCors__0="https://app.example.com"
+export Auth__Introspection__ClientId="admin-cli"
+export Auth__Introspection__ClientSecret="s3cr3t"
 ```
 
 ### Windows PowerShell
 ```powershell
 $env:ConnectionStrings__Default = "Server=..."
 $env:AstraId__Issuer = "https://id.example.com"
+$env:AstraId__AllowedCors__0 = "https://app.example.com"
+$env:Auth__Introspection__ClientId = "admin-cli"
+$env:Auth__Introspection__ClientSecret = "s3cr3t"
 ```
 
 ## Troubleshooting

--- a/scripts/config-new-local.ps1
+++ b/scripts/config-new-local.ps1
@@ -1,0 +1,8 @@
+$Template = "src/AstraID.Api/appsettings.Local.json.example"
+$Target = "src/AstraID.Api/appsettings.Local.json"
+if (Test-Path $Target) {
+    Write-Error "$Target already exists"
+    exit 1
+}
+Copy-Item $Template $Target
+Write-Host "Created $Target. Replace placeholder values (e.g., CHANGE_ME) before running the app."

--- a/scripts/config-new-local.sh
+++ b/scripts/config-new-local.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+TEMPLATE="src/AstraID.Api/appsettings.Local.json.example"
+TARGET="src/AstraID.Api/appsettings.Local.json"
+if [ -f "$TARGET" ]; then
+  echo "$TARGET already exists" >&2
+  exit 1
+fi
+cp "$TEMPLATE" "$TARGET"
+echo "Created $TARGET. Replace placeholder values (e.g., CHANGE_ME) before running the app."

--- a/src/AstraID.Api/Infrastructure/JsoncConfiguration/JsoncConfigurationProvider.cs
+++ b/src/AstraID.Api/Infrastructure/JsoncConfiguration/JsoncConfigurationProvider.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace AstraID.Api.Infrastructure.JsoncConfiguration;
+
+public class JsoncConfigurationProvider : FileConfigurationProvider
+{
+    public JsoncConfigurationProvider(JsoncConfigurationSource source) : base(source) { }
+
+    public override void Load(Stream stream)
+    {
+        using var reader = new StreamReader(stream);
+        var text = reader.ReadToEnd();
+        var noComments = Regex.Replace(text, @"//.*?$|/\*.*?\*/", string.Empty, RegexOptions.Singleline | RegexOptions.Multiline);
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(noComments));
+        var jsonProvider = new JsonConfigurationProvider(new JsonConfigurationSource());
+        jsonProvider.Load(ms);
+        Data = jsonProvider.Data;
+    }
+}
+
+public class JsoncConfigurationSource : FileConfigurationSource
+{
+    public override IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        EnsureDefaults(builder);
+        return new JsoncConfigurationProvider(this);
+    }
+}
+
+public static class JsoncConfigurationExtensions
+{
+    public static IConfigurationBuilder AddJsoncFile(this IConfigurationBuilder builder, string path, bool optional = false, bool reloadOnChange = false)
+    {
+        var source = new JsoncConfigurationSource
+        {
+            Path = path,
+            Optional = optional,
+            ReloadOnChange = reloadOnChange
+        };
+        return builder.Add(source);
+    }
+}

--- a/src/AstraID.Api/Options/AstraIdOptions.cs
+++ b/src/AstraID.Api/Options/AstraIdOptions.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 
 namespace AstraID.Api.Options;
 
@@ -22,6 +24,48 @@ public class RateLimitOptions
     [Range(1, 1000)]
     public int Rps { get; set; }
 
-    [Range(1, 1000)]
+    [Range(1, 5000)]
     public int Burst { get; set; }
+}
+
+public class AstraIdOptionsValidator : IValidateOptions<AstraIdOptions>
+{
+    private readonly IHostEnvironment _env;
+
+    public AstraIdOptionsValidator(IHostEnvironment env)
+        => _env = env;
+
+    public ValidateOptionsResult Validate(string? name, AstraIdOptions options)
+    {
+        var errors = new List<string>();
+
+        if (!Uri.TryCreate(options.Issuer, UriKind.Absolute, out var issuer) || issuer.Scheme != Uri.UriSchemeHttps)
+        {
+            errors.Add(ValidationError.Format("AstraId:Issuer", "must be an absolute HTTPS URL", "Set AstraId:Issuer to e.g. https://id.example.com"));
+        }
+
+        for (var i = 0; i < options.AllowedCors.Length; i++)
+        {
+            var origin = options.AllowedCors[i];
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+            {
+                errors.Add(ValidationError.Format($"AstraId:AllowedCors[{i}]", "must be an absolute URL", "Use full URL like https://app.example.com"));
+            }
+            else if (uri.Scheme != Uri.UriSchemeHttps && !(_env.IsDevelopment() && uri.Scheme == Uri.UriSchemeHttp))
+            {
+                errors.Add(ValidationError.Format($"AstraId:AllowedCors[{i}]", "must use HTTPS", "Use https:// origin or enable only in Development"));
+            }
+        }
+
+        if (options.RateLimit.Rps < 1 || options.RateLimit.Rps > 1000)
+            errors.Add(ValidationError.Format("AstraId:RateLimit:Rps", "must be between 1 and 1000", "Set AstraId:RateLimit:Rps within 1-1000"));
+
+        if (options.RateLimit.Burst < 1 || options.RateLimit.Burst > 5000)
+            errors.Add(ValidationError.Format("AstraId:RateLimit:Burst", "must be between 1 and 5000", "Set AstraId:RateLimit:Burst within 1-5000"));
+
+        if (options.RateLimit.Burst < options.RateLimit.Rps)
+            errors.Add(ValidationError.Format("AstraId:RateLimit", "Burst must be greater than or equal to Rps", "Increase Burst or lower Rps"));
+
+        return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
+    }
 }

--- a/src/AstraID.Api/Options/AuthOptions.cs
+++ b/src/AstraID.Api/Options/AuthOptions.cs
@@ -1,39 +1,88 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Options;
+using System.IO;
+using System.Collections.Generic;
 
 namespace AstraID.Api.Options;
 
 public class AuthOptions
 {
+    public ValidationMode ValidationMode { get; set; } = ValidationMode.Jwt;
     public TokenLifetimeOptions TokenLifetimes { get; set; } = new();
-
-    public CertificateOptions Certificates { get; set; } = new();
-
+    public CertificateCollectionOptions Certificates { get; set; } = new();
     public IntrospectionOptions Introspection { get; set; } = new();
+}
+
+public enum ValidationMode
+{
+    Jwt,
+    Introspection
 }
 
 public class TokenLifetimeOptions
 {
-    [Range(1, int.MaxValue)]
+    [Range(1, 240)]
     public int AccessMinutes { get; set; } = 60;
 
-    [Range(1, int.MaxValue)]
+    [Range(1, 240)]
     public int IdentityMinutes { get; set; } = 15;
 
-    [Range(1, int.MaxValue)]
+    [Range(1, 90)]
     public int RefreshDays { get; set; } = 14;
+}
+
+public class CertificateCollectionOptions
+{
+    public bool UseDevelopmentCertificates { get; set; }
+    public CertificateOptions[] Signing { get; set; } = Array.Empty<CertificateOptions>();
+    public CertificateOptions[] Encryption { get; set; } = Array.Empty<CertificateOptions>();
 }
 
 public class CertificateOptions
 {
-    public string[] Signing { get; set; } = Array.Empty<string>();
-    public string[] Encryption { get; set; } = Array.Empty<string>();
+    [Required]
+    public string Path { get; set; } = string.Empty;
+    public string? Password { get; set; }
 }
 
 public class IntrospectionOptions
 {
-    [Required]
-    public string ClientId { get; set; } = string.Empty;
+    public string? ClientId { get; set; }
+    public string? ClientSecret { get; set; }
+}
 
-    [Required]
-    public string ClientSecret { get; set; } = string.Empty;
+public class AuthOptionsValidator : IValidateOptions<AuthOptions>
+{
+    public ValidateOptionsResult Validate(string? name, AuthOptions options)
+    {
+        var errors = new List<string>();
+
+        if (!options.Certificates.UseDevelopmentCertificates)
+        {
+            if (options.Certificates.Signing.Length == 0)
+                errors.Add(ValidationError.Format("Auth:Certificates:Signing", "at least one signing certificate is required or enable UseDevelopmentCertificates", "Add certificate path or set UseDevelopmentCertificates=true"));
+            for (var i = 0; i < options.Certificates.Signing.Length; i++)
+            {
+                var cert = options.Certificates.Signing[i];
+                if (string.IsNullOrWhiteSpace(cert.Path) || !File.Exists(cert.Path))
+                    errors.Add(ValidationError.Format($"Auth:Certificates:Signing[{i}].Path", "file not found", "Ensure the certificate file exists or set UseDevelopmentCertificates=true"));
+            }
+            for (var i = 0; i < options.Certificates.Encryption.Length; i++)
+            {
+                var cert = options.Certificates.Encryption[i];
+                if (string.IsNullOrWhiteSpace(cert.Path) || !File.Exists(cert.Path))
+                    errors.Add(ValidationError.Format($"Auth:Certificates:Encryption[{i}].Path", "file not found", "Ensure the certificate file exists or set UseDevelopmentCertificates=true"));
+            }
+        }
+
+        if (options.ValidationMode == ValidationMode.Introspection)
+        {
+            if (string.IsNullOrWhiteSpace(options.Introspection.ClientId))
+                errors.Add(ValidationError.Format("Auth:Introspection:ClientId", "is required when ValidationMode is 'Introspection'", "Set Auth:Introspection:ClientId"));
+            if (string.IsNullOrWhiteSpace(options.Introspection.ClientSecret))
+                errors.Add(ValidationError.Format("Auth:Introspection:ClientSecret", "is required when ValidationMode is 'Introspection'", "Set Auth:Introspection:ClientSecret"));
+        }
+
+        return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
+    }
 }

--- a/src/AstraID.Api/Options/ConnectionStringsOptions.cs
+++ b/src/AstraID.Api/Options/ConnectionStringsOptions.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace AstraID.Api.Options;
+
+public class ConnectionStringsOptions
+{
+    [Required]
+    public string Default { get; set; } = string.Empty;
+}
+
+public class ConnectionStringsOptionsValidator : IValidateOptions<ConnectionStringsOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ConnectionStringsOptions options)
+    {
+        var errors = new List<string>();
+        if (string.IsNullOrWhiteSpace(options.Default))
+        {
+            errors.Add(ValidationError.Format("ConnectionStrings:Default", "must not be empty", "Provide a valid connection string"));
+        }
+        else
+        {
+            var builder = new DbConnectionStringBuilder { ConnectionString = options.Default };
+            var hasIntegrated = builder.TryGetValue("Integrated Security", out var integrated) && integrated?.ToString()?.Equals("True", StringComparison.OrdinalIgnoreCase) == true;
+            bool hasUser = builder.ContainsKey("User Id") || builder.ContainsKey("UserID") || builder.ContainsKey("UID");
+            bool hasPassword = builder.ContainsKey("Password") || builder.ContainsKey("PWD");
+            if (!(hasIntegrated || (hasUser && hasPassword)))
+            {
+                errors.Add(ValidationError.Format("ConnectionStrings:Default", "must include 'Integrated Security=True' or both 'User Id' and 'Password'", "Update connection string credentials"));
+            }
+        }
+        return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
+    }
+}

--- a/src/AstraID.Api/Options/ValidationError.cs
+++ b/src/AstraID.Api/Options/ValidationError.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+
+namespace AstraID.Api.Options;
+
+internal static class ValidationError
+{
+    public static string Format(string key, string message, string fix)
+        => string.Join('|', new[]{key, message, fix});
+
+    public static (string Key, string Message, string Fix) Parse(string value)
+    {
+        var parts = value.Split('|', 3);
+        return (
+            parts.ElementAtOrDefault(0) ?? string.Empty,
+            parts.ElementAtOrDefault(1) ?? string.Empty,
+            parts.ElementAtOrDefault(2) ?? string.Empty
+        );
+    }
+}

--- a/src/AstraID.Api/appsettings.Local.jsonc.example
+++ b/src/AstraID.Api/appsettings.Local.jsonc.example
@@ -1,22 +1,41 @@
 {
+  // === Database ===
+  // Use Windows auth (Integrated Security) OR SQL user credentials.
   "ConnectionStrings": {
-    "Default": "Server=YOUR_HOST\\SQLEXPRESS;Database=AstraID;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;"
+    "Default": "Server=AETERNUM\\SQLEXPRESS;Database=AstraID;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;"
   },
+
+  // === AstraID core ===
   "AstraId": {
+    // Public base URL of this identity server (must be HTTPS)
     "Issuer": "https://localhost:5001",
-    "AllowedCors": [ "https://localhost:5173" ],
+
+    // Allowed browser origins calling the API
+    "AllowedCors": [
+      "https://localhost:5173"
+    ],
+
+    // RPS: requests per second; Burst >= Rps
     "RateLimit": { "Rps": 10, "Burst": 20 },
+
+    // Enable only for DEV/TEST
     "AutoMigrate": false,
     "RunSeed": false
   },
+
+  // === Tokens & Certificates ===
   "Auth": {
     "ValidationMode": "Jwt",
     "TokenLifetimes": { "AccessMinutes": 60, "IdentityMinutes": 15, "RefreshDays": 14 },
+
+    // If omitted in DEV, development certs are used automatically
     "Certificates": {
       "UseDevelopmentCertificates": false,
       "Signing": [ { "Path": "C:\\certs\\astraid-signing.pfx", "Password": "CHANGE_ME" } ],
       "Encryption": [ { "Path": "C:\\certs\\astraid-encryption.pfx", "Password": "CHANGE_ME" } ]
     },
+
+    // Required if you use introspection validation
     "Introspection": { "ClientId": "admin-cli", "ClientSecret": "CHANGE_ME" }
   }
 }

--- a/src/AstraID.Api/appsettings.json
+++ b/src/AstraID.Api/appsettings.json
@@ -8,9 +8,11 @@
     "RunSeed": false
   },
   "Auth": {
+    "ValidationMode": "Jwt",
     "TokenLifetimes": { "AccessMinutes": 60, "IdentityMinutes": 15, "RefreshDays": 14 },
-    "Certificates": { "Signing": [], "Encryption": [] },
+    "Certificates": { "UseDevelopmentCertificates": true, "Signing": [], "Encryption": [] },
     "Introspection": { "ClientId": "", "ClientSecret": "" }
   },
-  "Serilog": { "MinimumLevel": "Information", "WriteTo": [ { "Name": "Console" } ] }
+  "Serilog": { "MinimumLevel": "Information", "WriteTo": [ { "Name": "Console" } ] },
+  "UseJsonc": false
 }

--- a/tests/AstraID.Api.Tests/OptionsValidationTests.cs
+++ b/tests/AstraID.Api.Tests/OptionsValidationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using AstraID.Api.Options;
+using AstraID.Api.Infrastructure.JsoncConfiguration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+class FakeHostEnvironment : IHostEnvironment
+{
+    public FakeHostEnvironment(string env)
+    {
+        EnvironmentName = env;
+        ApplicationName = "Test";
+        ContentRootPath = ".";
+    }
+    public string EnvironmentName { get; set; }
+    public string ApplicationName { get; set; }
+    public string ContentRootPath { get; set; }
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}
+
+public class AstraIdOptionsValidatorTests
+{
+    [Fact]
+    public void InvalidIssuerFails()
+    {
+        var options = new AstraIdOptions { Issuer = "http://localhost", AllowedCors = Array.Empty<string>(), RateLimit = new RateLimitOptions { Rps = 1, Burst = 1 } };
+        var validator = new AstraIdOptionsValidator(new FakeHostEnvironment("Production"));
+        var result = validator.Validate(null, options);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public void HttpCorsNotAllowedInProduction()
+    {
+        var options = new AstraIdOptions { Issuer = "https://example.com", AllowedCors = new[] { "http://example.com" }, RateLimit = new RateLimitOptions { Rps = 1, Burst = 1 } };
+        var validator = new AstraIdOptionsValidator(new FakeHostEnvironment("Production"));
+        var result = validator.Validate(null, options);
+        Assert.False(result.Succeeded);
+    }
+}
+
+public class ConnectionStringsOptionsValidatorTests
+{
+    [Fact]
+    public void EmptyConnectionStringFails()
+    {
+        var options = new ConnectionStringsOptions { Default = string.Empty };
+        var validator = new ConnectionStringsOptionsValidator();
+        var result = validator.Validate(null, options);
+        Assert.False(result.Succeeded);
+    }
+}
+
+public class AuthOptionsValidatorTests
+{
+    [Fact]
+    public void MissingIntrospectionSecretFails()
+    {
+        var options = new AuthOptions
+        {
+            ValidationMode = ValidationMode.Introspection,
+            Introspection = new IntrospectionOptions { ClientId = "id", ClientSecret = "" },
+            Certificates = new CertificateCollectionOptions { UseDevelopmentCertificates = true }
+        };
+        var validator = new AuthOptionsValidator();
+        var result = validator.Validate(null, options);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public void MissingCertificateFileFails()
+    {
+        var options = new AuthOptions
+        {
+            Certificates = new CertificateCollectionOptions
+            {
+                UseDevelopmentCertificates = false,
+                Signing = new[] { new CertificateOptions { Path = "nonexistent.pfx" } },
+                Encryption = Array.Empty<CertificateOptions>()
+            }
+        };
+        var validator = new AuthOptionsValidator();
+        var result = validator.Validate(null, options);
+        Assert.False(result.Succeeded);
+    }
+}
+
+public class JsoncConfigurationProviderTests
+{
+    [Fact]
+    public void CommentsAreIgnored()
+    {
+        var temp = Path.GetTempFileName();
+        File.WriteAllText(temp, "{\n//c1\n\"A\":1/*b*/\n}");
+        var config = new ConfigurationBuilder().AddJsoncFile(temp, optional: false, reloadOnChange: false).Build();
+        Assert.Equal("1", config["A"]);
+        File.Delete(temp);
+    }
+}


### PR DESCRIPTION
## Summary
- add validated options for AstraId, Auth and ConnectionStrings
- support optional JSONC configuration files with comment stripping provider
- document configuration setup and add scripts for local templates

## Testing
- ⚠️ `dotnet test` *(dotnet command not found; attempted installation but no .NET 9 SDK package available)*


------
https://chatgpt.com/codex/tasks/task_e_68a4327f256c83268f00c4678d651c2b