### PR TITLE
Add configurable OAuth endpoints and token format

### DIFF
--- a/src/AstraID.Api/appsettings.json
+++ b/src/AstraID.Api/appsettings.json
@@ -5,10 +5,13 @@
     "AllowedCors": [ "https://localhost:5173" ],
     "RateLimit": { "Rps": 10, "Burst": 20 },
     "AutoMigrate": false,
-    "RunSeed": false
+    "RunSeed": false,
+    "RequireParForPublicClients": false
   },
   "Auth": {
     "ValidationMode": "Jwt",
+    "AccessTokenFormat": "Jwt",
+    "Scopes": [],
     "TokenLifetimes": { "AccessMinutes": 60, "IdentityMinutes": 15, "RefreshDays": 14 },
     "Certificates": { "UseDevelopmentCertificates": true, "Signing": [], "Encryption": [] },
     "Introspection": { "ClientId": "", "ClientSecret": "" }

--- a/tests/AstraID.IntegrationTests/OidcTests.cs
+++ b/tests/AstraID.IntegrationTests/OidcTests.cs
@@ -83,7 +83,7 @@ public class OidcTests : IClassFixture<TestFactory>
     [Fact]
     public async Task Jwks_Exposed()
     {
-        var json = await _client.GetFromJsonAsync<Dictionary<string, object>>("/.well-known/jwks");
+        var json = await _client.GetFromJsonAsync<Dictionary<string, object>>("/connect/jwks");
         json!.Should().NotBeNull();
     }
 
@@ -101,6 +101,7 @@ public class OidcTests : IClassFixture<TestFactory>
         opt.AccessTokenLifetime.Should().Be(TimeSpan.FromMinutes(60));
         opt.IdentityTokenLifetime.Should().Be(TimeSpan.FromMinutes(15));
         opt.RefreshTokenLifetime.Should().Be(TimeSpan.FromDays(14));
+        opt.UseReferenceAccessTokens.Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expose additional OpenIddict endpoints and tighten PKCE configuration
- support JWT or reference access tokens and custom scopes via configuration
- wire up config sample and integration tests for new JWKS path

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a43dcfe7f883268e34a3a528bf974a