### PR TITLE
Register domain services and support providers

### DIFF
--- a/src/AstraID.Infrastructure/Services/AspNetPasswordHasher.cs
+++ b/src/AstraID.Infrastructure/Services/AspNetPasswordHasher.cs
@@ -1,0 +1,22 @@
+using AstraID.Domain.Abstractions;
+using AstraID.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+
+namespace AstraID.Infrastructure.Services;
+
+/// <summary>Adapter over ASP.NET Identity password hasher for domain usage.</summary>
+public sealed class AspNetPasswordHasher : IPasswordHasher
+{
+    private readonly IPasswordHasher<AppUser> _hasher;
+
+    public AspNetPasswordHasher(IPasswordHasher<AppUser> hasher)
+        => _hasher = hasher;
+
+    /// <inheritdoc />
+    public string Hash(string password)
+        => _hasher.HashPassword(null!, password);
+
+    /// <inheritdoc />
+    public bool Verify(string hash, string password)
+        => _hasher.VerifyHashedPassword(null!, hash, password) != PasswordVerificationResult.Failed;
+}

--- a/src/AstraID.Infrastructure/Services/DefaultPasswordPolicy.cs
+++ b/src/AstraID.Infrastructure/Services/DefaultPasswordPolicy.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using AstraID.Domain.Abstractions;
+
+namespace AstraID.Infrastructure.Services;
+
+/// <summary>Simple password policy enforcing basic complexity rules.</summary>
+public sealed class DefaultPasswordPolicy : IPasswordPolicy
+{
+    /// <inheritdoc />
+    public string? ValidateStrength(string password)
+    {
+        if (string.IsNullOrWhiteSpace(password) || password.Length < 12)
+            return "Password must be at least 12 characters long.";
+        if (!password.Any(char.IsUpper))
+            return "Password must contain an uppercase letter.";
+        if (!password.Any(char.IsLower))
+            return "Password must contain a lowercase letter.";
+        if (!password.Any(char.IsDigit))
+            return "Password must contain a digit.";
+        return null;
+    }
+}

--- a/src/AstraID.Infrastructure/Services/SystemDateTimeProvider.cs
+++ b/src/AstraID.Infrastructure/Services/SystemDateTimeProvider.cs
@@ -1,0 +1,14 @@
+using AstraID.Application.Abstractions;
+using DomainDateTimeProvider = AstraID.Domain.Abstractions.IDateTimeProvider;
+
+namespace AstraID.Infrastructure.Services;
+
+/// <summary>Provides the current system time.</summary>
+public sealed class SystemDateTimeProvider : IDateTimeProvider, DomainDateTimeProvider
+{
+    /// <inheritdoc />
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+
+    /// <inheritdoc />
+    DateTime DomainDateTimeProvider.UtcNow => DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary
- add infrastructure services for password hashing, password policy, and system clock
- register domain services and policies in infrastructure DI setup
- expose DbContext for outbox publisher and wire up shared date-time provider

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a775db429483269d37f08fa1d5957b