### PR TITLE
Register date time provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ All notable changes to this project will be documented in this file.
 - Revamped documentation for installation, configuration, security and troubleshooting.
 - Added readiness report, action plan and expanded test plan.
 - Clarified certificate strategy and rate limiting guidance.
+- Fixed missing IDateTimeProvider registrations causing service resolution failures.
 

--- a/src/AstraID.Api/Program.cs
+++ b/src/AstraID.Api/Program.cs
@@ -21,6 +21,7 @@ using AstraID.Api.Tls;
 using AstraID.Api.Services;
 using Microsoft.Extensions.Options;
 using CorrelationId.DependencyInjection;
+using AstraID.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -89,6 +90,9 @@ builder.Services.AddSingleton<IValidateOptions<LetsEncryptOptions>, LetsEncryptO
 
 builder.Services.AddRouting();
 builder.Services.AddCorrelationId();
+
+builder.Services.AddSingleton<AstraID.Application.Abstractions.IDateTimeProvider, SystemDateTimeProvider>();
+builder.Services.AddSingleton<AstraID.Domain.Abstractions.IDateTimeProvider, SystemDateTimeProvider>();
 
 builder.Services
     .AddAstraIdApplication()

--- a/src/AstraID.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AstraID.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using AstraID.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace AstraID.Infrastructure.DependencyInjection;
 
@@ -65,8 +66,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ConsentPolicy>();
 
         // Cross-layer services
-        services.AddSingleton<AstraID.Application.Abstractions.IDateTimeProvider, SystemDateTimeProvider>();
-        services.AddSingleton<AstraID.Domain.Abstractions.IDateTimeProvider, SystemDateTimeProvider>();
+        services.TryAddSingleton<AstraID.Application.Abstractions.IDateTimeProvider, SystemDateTimeProvider>();
+        services.TryAddSingleton<AstraID.Domain.Abstractions.IDateTimeProvider, SystemDateTimeProvider>();
         services.AddScoped<IPasswordPolicy, DefaultPasswordPolicy>();
         services.AddScoped<IPasswordHasher, AspNetPasswordHasher>();
 


### PR DESCRIPTION
## Summary
- register SystemDateTimeProvider for application and domain layers
- guard infrastructure clock registrations against duplicates

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a779d95e38832691b30dd08d4c7b79