### PR TITLE
Refactor SystemDateTimeProvider into shared services

### DIFF
--- a/src/AstraID.Api/Program.cs
+++ b/src/AstraID.Api/Program.cs
@@ -21,7 +21,7 @@ using AstraID.Api.Tls;
 using AstraID.Api.Services;
 using Microsoft.Extensions.Options;
 using CorrelationId.DependencyInjection;
-using AstraID.Infrastructure.Services;
+using AstraID.Shared.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/AstraID.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AstraID.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using AstraID.Infrastructure.Persistence;
 using AstraID.Infrastructure.Persistence.Interceptors;
 using AstraID.Infrastructure.Persistence.Repositories;
 using AstraID.Infrastructure.Services;
+using AstraID.Shared.Services;
 using AstraID.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/src/AstraID.Shared/Services/SystemDateTimeProvider.cs
+++ b/src/AstraID.Shared/Services/SystemDateTimeProvider.cs
@@ -1,7 +1,7 @@
 using AstraID.Application.Abstractions;
 using DomainDateTimeProvider = AstraID.Domain.Abstractions.IDateTimeProvider;
 
-namespace AstraID.Infrastructure.Services;
+namespace AstraID.Shared.Services;
 
 /// <summary>Provides the current system time.</summary>
 public sealed class SystemDateTimeProvider : IDateTimeProvider, DomainDateTimeProvider


### PR DESCRIPTION
## Summary
- move `SystemDateTimeProvider` from infrastructure to shared project
- register shared provider in DI for API and infrastructure layers

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a784e75f988326a76ce54888225f8a