### PR TITLE
Fix key mapping for owned client collections

### DIFF
--- a/src/AstraID.Persistence/Configurations/ClientConfiguration.cs
+++ b/src/AstraID.Persistence/Configurations/ClientConfiguration.cs
@@ -46,7 +46,7 @@ internal sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
                 .HasColumnName("Name")
                 .HasMaxLength(128)
                 .HasColumnType("nvarchar(128)");
-            b.HasKey("ClientId", "Name");
+            b.HasKey("ClientId", "Value");
         });
 
         builder.OwnsMany<RedirectUri>("_redirectUris", b =>
@@ -57,7 +57,7 @@ internal sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
                 .HasColumnName("Uri")
                 .HasMaxLength(2048)
                 .HasColumnType("nvarchar(2048)");
-            b.HasKey("ClientId", "Uri");
+            b.HasKey("ClientId", "Value");
         });
 
         builder.OwnsMany<RedirectUri>("_postLogoutRedirectUris", b =>
@@ -68,7 +68,7 @@ internal sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
                 .HasColumnName("Uri")
                 .HasMaxLength(2048)
                 .HasColumnType("nvarchar(2048)");
-            b.HasKey("ClientId", "Uri");
+            b.HasKey("ClientId", "Value");
         });
 
         builder.Navigation("_scopes").UsePropertyAccessMode(PropertyAccessMode.Field);


### PR DESCRIPTION
## Summary
- fix composite keys for Client scopes and redirect URIs by using actual property name

## Testing
- `dotnet test tests/AstraID.Persistence.Tests`


------
https://chatgpt.com/codex/tasks/task_e_68a856f7095883268a7d475f4f3baf58