### PR TITLE
Correct UserConsent scope key property

### DIFF
--- a/src/AstraID.Persistence/Configurations/UserConsentConfiguration.cs
+++ b/src/AstraID.Persistence/Configurations/UserConsentConfiguration.cs
@@ -29,7 +29,7 @@ internal sealed class UserConsentConfiguration : IEntityTypeConfiguration<UserCo
                 .HasColumnName("Name")
                 .HasMaxLength(128)
                 .HasColumnType("nvarchar(128)");
-            b.HasKey("ConsentId", "Name");
+            b.HasKey("ConsentId", nameof(Scope.Value));
         });
 
         builder.Navigation("_scopes").UsePropertyAccessMode(PropertyAccessMode.Field);


### PR DESCRIPTION
## Summary
- fix UserConsent scope key to use Value property

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a8597ad7248326b418acab4bb1d521