### PR TITLE
Ignore redundant EF Core navigation

### DIFF
--- a/src/AstraID.Persistence/Configurations/ClientConfiguration.cs
+++ b/src/AstraID.Persistence/Configurations/ClientConfiguration.cs
@@ -38,6 +38,14 @@ internal sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
         builder.Property(c => c.TenantId)
             .HasColumnType("uniqueidentifier");
 
+        // EF Core attempts to map the public navigation property
+        // `PostLogoutRedirectUris` automatically which causes a model
+        // validation error when using the backing field configuration.
+        // Explicitly ignoring the property avoids the duplicate mapping and
+        // lets the owned collection configuration for `_postLogoutRedirectUris`
+        // take effect.
+        builder.Ignore(c => c.PostLogoutRedirectUris);
+
         builder.OwnsMany<Scope>("_scopes", b =>
         {
             b.ToTable("ClientScopes");


### PR DESCRIPTION
## Summary
- ignore `Client.PostLogoutRedirectUris` navigation to prevent EF Core model validation error

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a85d031cc08326aab1292df8a33af9