### PR TITLE
Ignore client redirect navigation to fix model validation

### DIFF
--- a/src/AstraID.Persistence/Configurations/ClientConfiguration.cs
+++ b/src/AstraID.Persistence/Configurations/ClientConfiguration.cs
@@ -38,12 +38,13 @@ internal sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
         builder.Property(c => c.TenantId)
             .HasColumnType("uniqueidentifier");
 
-        // EF Core attempts to map the public navigation property
-        // `PostLogoutRedirectUris` automatically which causes a model
-        // validation error when using the backing field configuration.
-        // Explicitly ignoring the property avoids the duplicate mapping and
-        // lets the owned collection configuration for `_postLogoutRedirectUris`
-        // take effect.
+        // EF Core attempts to map the public navigation properties
+        // `RedirectUris` and `PostLogoutRedirectUris` automatically which
+        // causes a model validation error when using the backing field
+        // configuration. Explicitly ignoring the properties avoids the
+        // duplicate mapping and lets the owned collection configurations
+        // for `_redirectUris` and `_postLogoutRedirectUris` take effect.
+        builder.Ignore(c => c.RedirectUris);
         builder.Ignore(c => c.PostLogoutRedirectUris);
 
         builder.OwnsMany<Scope>("_scopes", b =>


### PR DESCRIPTION
## Summary
- ignore client RedirectUris navigation to avoid duplicate mapping in EF Core

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a862c63e108326ab4f74b4b2609253